### PR TITLE
Images are placed from top if it's portrait and are coming in middle if it's landscape. #16 solved !

### DIFF
--- a/projects/ngx-stories/src/lib/ngx-stories.component.scss
+++ b/projects/ngx-stories/src/lib/ngx-stories.component.scss
@@ -137,6 +137,9 @@ button:nth-child(1) {
   justify-content: space-between;
   align-items: center;
   z-index: 1;
+  h5{
+    color: white;
+  }
 
   button {
     display: none;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,6 +2,7 @@
 
 
 <ngx-stories
+[options]="{ width: 338, height: 600 }"
 [storyGroups]="storyGroups"
 backlitColor="#1b1b1b" 
 (triggerOnEnd)="triggerOnEnd()"


### PR DESCRIPTION
Vertical Images are centered now
I have adjusted the height of the story for a better visibility in both laptops and mobile phones !