### PR TITLE
fix: pause previous video on keyboard navigation

### DIFF
--- a/projects/ngx-stories/src/lib/ngx-stories.component.ts
+++ b/projects/ngx-stories/src/lib/ngx-stories.component.ts
@@ -257,17 +257,14 @@ export class NgxStoriesComponent implements AfterViewInit {
   }
 
   private pauseCurrentVideo(seek: null | boolean = null) {
-    let currentStory = this.storyGroups.find((storyGroup, index) => index === this.currentStoryGroupIndex)?.stories[this.currentStoryIndex];
-    if (currentStory?.type === 'video') {
-      const activeStoryContainer = this.storyContainers.toArray()[this.currentStoryGroupIndex]; // Current story group container
-      const activeStoryContent = activeStoryContainer.nativeElement.querySelector('.story-content.active'); // Active story within the group
-      const videoElement: HTMLVideoElement | null = activeStoryContent.querySelector('video');
-
-      if (videoElement) {
-        videoElement.pause();
-        seek && (videoElement.currentTime = 0);
-      }
-    }
+    // Pause all videos in all story containers
+    this.storyContainers?.forEach(container => {
+      const videos = container.nativeElement.querySelectorAll('video');
+      videos.forEach((video: HTMLVideoElement) => {
+        video.pause();
+        if (seek) video.currentTime = 0;
+      });
+    });
   }
 
   private goToNextStoryGroup() {


### PR DESCRIPTION
## Describe your changes
Fixed an issue where, when navigating stories using the keyboard arrow keys, the previous video would continue playing in the background.
Now, all videos are paused before navigating to the next or previous story, ensuring only the current story's video plays.
The fix was implemented by calling [pauseCurrentVideo()](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) before navigation in the [navigateStory](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) method, which is triggered by both button and keyboard navigation.


## Issue ticket number and link - If Any
 fix - #52

## Checklist before requesting a review

- [x] I have performed a self-review of my code.

- [x] Followed the repository's [Contributing Guidelines](https://github.com/Gauravdarkslayer/ngx-stories/blob/main/CONTRIBUTING.md).

- [x] I ran the app and tested it locally to verify that it works as expected.

- [x] I have starred the repository.

